### PR TITLE
[TECH] Run releases on tagged commits

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   publish:
-    if: ${{ contains(github.event.pull_request.title, '[RELEASE]') }}
+    #  run on any tagged commit
+    if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The conditional publishing hasn't been triggering - this is because the PR title isn't available as a Github context during push.

Changing to a solution based on git tags:

```
git tag -a v1.4 -m "my version 1.4"
```