### PR TITLE
MMSDM archive naming update

### DIFF
--- a/nemdata/mmsdm.py
+++ b/nemdata/mmsdm.py
@@ -150,15 +150,17 @@ def make_one_mmsdm_file(
     year: int, month: int, table: MMSDMTable, base_directory: pathlib.Path
 ) -> MMSDMFile:
     """creates a single MMSDMFile object that represents one file on the AEMO MMSDM website"""
-    #  zero pad the month - 3 -> 03
     padded_month = str(month).zfill(2)
 
-    #  url to the zipfile on MMSDM website
     url_prefix = f"https://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/{year}/MMSDM_{year}_{padded_month}/MMSDM_Historical_Data_SQLLoader"
-    url = f"{url_prefix}/{table.directory}/PUBLIC_DVD_{table.table}_{year}{padded_month}010000.zip"
 
-    #  name of the CSV that comes out of the zipfile
-    csv_name = f"PUBLIC_DVD_{table.table}_{year}{padded_month}010000.CSV"
+    if (year, month) >= (2024, 8):
+        filename_base = f"PUBLIC_ARCHIVE%23{table.table}%23FILE01%23{year}{padded_month}010000"
+        url = f"{url_prefix}/{table.directory}/{filename_base}.zip"
+        csv_name = f"PUBLIC_ARCHIVE#{table.table}#FILE01#{year}{padded_month}010000.CSV"
+    else:
+        url = f"{url_prefix}/{table.directory}/PUBLIC_DVD_{table.table}_{year}{padded_month}010000.zip"
+        csv_name = f"PUBLIC_DVD_{table.table}_{year}{padded_month}010000.CSV"
 
     #  data directory where we will download data to
     data_directory = base_directory / table.name / f"{year}-{padded_month}"

--- a/tests/test_mmsdm_file.py
+++ b/tests/test_mmsdm_file.py
@@ -52,10 +52,10 @@ from nemdata import mmsdm
         ),
         (
             2025,
-            6,
+            5,
             "TRADINGPRICE",
             "trading-price",
-            "https://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/2025/MMSDM_2025_06/MMSDM_Historical_Data_SQLLoader/DATA/PUBLIC_ARCHIVE%23TRADINGPRICE%23FILE01%23202506010000.zip",
+            "https://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/2025/MMSDM_2025_05/MMSDM_Historical_Data_SQLLoader/DATA/PUBLIC_ARCHIVE%23TRADINGPRICE%23FILE01%23202505010000.zip",
         ),
     ],
 )

--- a/tests/test_mmsdm_file.py
+++ b/tests/test_mmsdm_file.py
@@ -29,6 +29,34 @@ from nemdata import mmsdm
             "interconnectors",
             "https://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/2010/MMSDM_2010_12/MMSDM_Historical_Data_SQLLoader/DATA/PUBLIC_DVD_DISPATCHINTERCONNECTORRES_201012010000.zip",
         ),
+        (
+            2024,
+            7,
+            "DISPATCHPRICE",
+            "dispatch-price",
+            "https://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/2024/MMSDM_2024_07/MMSDM_Historical_Data_SQLLoader/DATA/PUBLIC_DVD_DISPATCHPRICE_202407010000.zip",
+        ),
+        (
+            2024,
+            8,
+            "DISPATCHPRICE",
+            "dispatch-price",
+            "https://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/2024/MMSDM_2024_08/MMSDM_Historical_Data_SQLLoader/DATA/PUBLIC_ARCHIVE%23DISPATCHPRICE%23FILE01%23202408010000.zip",
+        ),
+        (
+            2025,
+            1,
+            "DISPATCHPRICE",
+            "dispatch-price",
+            "https://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/2025/MMSDM_2025_01/MMSDM_Historical_Data_SQLLoader/DATA/PUBLIC_ARCHIVE%23DISPATCHPRICE%23FILE01%23202501010000.zip",
+        ),
+        (
+            2025,
+            6,
+            "TRADINGPRICE",
+            "trading-price",
+            "https://www.nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/2025/MMSDM_2025_06/MMSDM_Historical_Data_SQLLoader/DATA/PUBLIC_ARCHIVE%23TRADINGPRICE%23FILE01%23202506010000.zip",
+        ),
     ],
 )
 def test_form_report_url(


### PR DESCRIPTION
## Summary
Updates MMSDM filenames to correct format where relevant. File structure remains the same.

e.g.
https://nemweb.com.au/Data_Archive/Wholesale_Electricity/MMSDM/2024/MMSDM_2024_08/MMSDM_Historical_Data_SQLLoader/DATA/PUBLIC_ARCHIVE%23DISPATCHPRICE%23FILE01%23202408010000.zip

i.e. 
f"PUBLIC_ARCHIVE#{table.table}#FILE01#{year}{padded_month}010000.CSV"


## Background / Context
Since August 24, MMSDM filenames have changed.

## Changes
- add check for requests >= 08-2024, use updated file naming

## Testing
- added tests for 2025 data, all passed

[tests.txt](https://github.com/user-attachments/files/25591406/tests.txt)
